### PR TITLE
[FlurryAnalytics] Allow null "parameters"  for EndTimedEvent.

### DIFF
--- a/FlurryAnalytics/binding/FlurryAnalytics.cs
+++ b/FlurryAnalytics/binding/FlurryAnalytics.cs
@@ -58,7 +58,7 @@ namespace FlurryAnalytics
 
 		[Static]
 		[Export ("endTimedEvent:withParameters:")]
-		void EndTimedEvent (string eventName, NSDictionary parameters);
+		void EndTimedEvent (string eventName, [NullAllowed]NSDictionary parameters);
 	
 		// automatically track page view on UINavigationController or UITabBarController
 		[Static]


### PR DESCRIPTION
## Supporting evidence

Flurry's sample usage for logEvent:timed: illustrates that passing
nil for endTimedEvent:withParameters: is valid.

http://support.flurry.com/sdkdocs/iOS/interface_flurry_analytics.html#a07294619bfe4253a6218dddfc4a2223d
