### PR TITLE
facebook: Make Accounts and Social WeakFrameworks for iOS < 6

### DIFF
--- a/facebook/binding/AssemblyInfo.cs
+++ b/facebook/binding/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System;
 using MonoTouch.ObjCRuntime;
 
-[assembly: LinkWith ("libFacebookSDK.a", LinkTarget.Simulator | LinkTarget.ArmV7 | LinkTarget.ArmV7s, "-ObjC -lsqlite3", ForceLoad = true, Frameworks = "Accounts CoreGraphics CoreLocation QuartzCore Social", WeakFrameworks = "AdSupport")]
+[assembly: LinkWith ("libFacebookSDK.a", LinkTarget.Simulator | LinkTarget.ArmV7 | LinkTarget.ArmV7s, "-ObjC -lsqlite3", ForceLoad = true, Frameworks = "CoreGraphics CoreLocation QuartzCore", WeakFrameworks = "Accounts AdSupport Social")]


### PR DESCRIPTION
Social.framework is only available in iOS 6.  Accounts.framework is available in iOS 5 but still needs to be weakly linked (see http://developers.facebridge.net/bugs/151020075041952?browse=search_507161bbeb6c42b26696046).

Tested with iOS 4/5/6 simulators.
