### PR TITLE
Minor update to the Parse bindings

### DIFF
--- a/Parse/binding/ParseLib.cs
+++ b/Parse/binding/ParseLib.cs
@@ -863,7 +863,7 @@ namespace ParseLib
                 string DeviceToken { get; }	
 
 	        [Export ("badge")]
-                int Badge { get; }	
+                int Badge { get; set; }	
 
 	        [Export ("timeZone")]
                 string TimeZone { get; }	


### PR DESCRIPTION
The Parse binding was missing a setter for PFInstallation.badge - this is needed for updating/resetting the app badge number after receiving push notifications that increment the app badge number.
