### PR TITLE
Fixed a build issue (added Dependency Ref CoreLocation)

### DIFF
--- a/RedLaser/binding/AssemblyInfo.cs
+++ b/RedLaser/binding/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System;
 using MonoTouch.ObjCRuntime;
 
-[assembly: LinkWith ("libRedLaserSDK.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7, Frameworks = "AudioToolbox AVFoundation CFNetwork CoreMedia CoreVideo OpenGLES Security SystemConfiguration", ForceLoad = true, IsCxx = true, NeedsGccExceptionHandling = true)]
+[assembly: LinkWith ("libRedLaserSDK.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7, Frameworks = "AudioToolbox AVFoundation CFNetwork CoreMedia CoreVideo OpenGLES Security SystemConfiguration CoreLocation", ForceLoad = true, IsCxx = true, NeedsGccExceptionHandling = true)]


### PR DESCRIPTION
Added CoreLocation reference to Frameworks attributes in AssemblyInfo on RedLaser Sample Code to fix a build problem 
Please refer to the issue below on StackOverflow for the details of the issue

http://stackoverflow.com/questions/14332416/monotouch-app-cannot-build-deploy-to-iphone-device-but-it-works-fine-on-isimulat
