### PR TITLE
cocos2d: bind TouchMode and TouchPriority

### DIFF
--- a/cocos2d/binding/ApiDefinition.cs
+++ b/cocos2d/binding/ApiDefinition.cs
@@ -1184,7 +1184,14 @@ namespace MonoTouch.Cocos2D {
 
 		[Export ("isTouchEnabled")]
 		bool IsTouchEnabled { get; set; }
-
+		
+#if !MONOMAC
+		[Export ("touchMode")]
+		CCTouchesMode TouchMode { get; set; }
+#endif
+		[Export ("touchPriority")]
+		int TouchPriority { get; set; }
+		
 		[Export ("isAccelerometerEnabled")]
 		bool IsAccelerometerEnabled { get; set; }
 

--- a/cocos2d/binding/StructsAndEnums.cs
+++ b/cocos2d/binding/StructsAndEnums.cs
@@ -260,4 +260,11 @@ namespace MonoTouch.Cocos2D {
 		FlippedAll = Horizontal | Vertical | Diagonal,
 		FlippedMask = ~FlippedAll
 	}
+
+#if !MONOMAC
+	public enum CCTouchesMode {
+		AllAtOnce,
+		OneByOne,
+	}
+#endif
 }


### PR DESCRIPTION
Required to get OneByOne touch support, which are easier to deal with
