### PR TITLE
Switching to version 1.1

### DIFF
--- a/TestFlight/README
+++ b/TestFlight/README
@@ -5,7 +5,7 @@ This is a MonoTouch binding for the TestFlight SDK which can be found at
 
      https://testflightapp.com/sdk/
 
-The current version of this binding is for TestFlight SDK 1.0
+The current version of this binding is for TestFlight SDK 1.1
 
 
 Building

--- a/TestFlight/binding/Makefile
+++ b/TestFlight/binding/Makefile
@@ -1,5 +1,5 @@
 BTOUCH=/Developer/MonoTouch/usr/bin/btouch
-VERSION=1.0
+VERSION=1.1
 all: TestFlight.dll
 
 TestFlightSDK$(VERSION).zip:


### PR DESCRIPTION
Changing the binding to pull and bind to v1.1 of the TestFlight SDK.
