### PR TITLE
DropboxSync: fixed the base classes for a few bindings in the dropbox sync api.

### DIFF
--- a/DropBoxSync/binding/ApiDefinition.cs
+++ b/DropBoxSync/binding/ApiDefinition.cs
@@ -77,7 +77,7 @@ namespace DropBoxSync.iOS
 		DBErrorCode Code { get; }
 	}
 
-	[BaseType (typeof (NSError))]
+	[BaseType (typeof (NSObject))]
 	interface DBFile {
 
 		// TODO: Missing for now
@@ -124,7 +124,7 @@ namespace DropBoxSync.iOS
 		void RemoveObserver (NSObject observer);
 	}
 
-	[BaseType (typeof (NSError))]
+	[BaseType (typeof (NSObject))]
 	interface DBFileInfo {
 
 		[Export ("path")]
@@ -140,7 +140,7 @@ namespace DropBoxSync.iOS
 		long Size { get; }
 	}
 
-	[BaseType (typeof (NSError))]
+	[BaseType (typeof (NSObject))]
 	interface DBFileStatus {
 
 		[Export ("cached")]
@@ -156,7 +156,7 @@ namespace DropBoxSync.iOS
 		DBError Error { get; }
 	}
 
-	[BaseType (typeof (NSError))]
+	[BaseType (typeof (NSObject))]
 	interface DBFilesystem {
 
 		[Export ("initWithAccount:")]
@@ -214,7 +214,7 @@ namespace DropBoxSync.iOS
 		void RemoveObserver (NSObject observer);
 	}
 
-	[BaseType (typeof (NSError))]
+	[BaseType (typeof (NSObject))]
 	interface DBPath {
 
 		[Static, Export ("root")]

--- a/DropBoxSync/binding/Makefile
+++ b/DropBoxSync/binding/Makefile
@@ -4,10 +4,10 @@ SMCS=/Developer/MonoTouch/usr/bin/smcs
 all: DropBoxSync.iOS.dll
 
 DropBoxSync.zip: 
-	curl -L https://dl.dropbox.com/shz/fp8nbrl21iqwhv8/QKlj_3ZHS5/dropbox-ios-sync-sdk-1.0?top_level_offset=14 > $@
+	curl -L "https://dl.dropbox.com/shz/vmgga8sf8tduqpn/LJCXOVNr7L/Dropbox.framework/Dropbox.framework?token_hash=AAFliKaJE9Xme-7o-2d6t8FVBHx_FHMW4fxwMVOQFT44TQ&top_level_offset=48&dl=1" > $@
 
 Dropbox.a: DropBoxSync.zip
-	unzip -p $< 'dropbox-ios-sync-sdk-1.0/Dropbox.framework/Dropbox' > $@
+	unzip -p $< 'Dropbox.framework/Dropbox' > $@
 
 DropBoxSync.iOS.dll: Makefile AssemblyInfo.cs ApiDefinition.cs StructsAndEnums.cs Dropbox.a
 	-mkdir -p ios


### PR DESCRIPTION
Also updated to point to the new ios sync api  (1.0.4) in the makefile.
verified this on the simulator
