### PR TITLE
Fixed UrbanAirship: Frameworks

### DIFF
--- a/UrbanAirShip/binding/AssemblyInfo.cs
+++ b/UrbanAirShip/binding/AssemblyInfo.cs
@@ -2,4 +2,4 @@ using System;
 using MonoTouch.ObjCRuntime;
 
 [assembly: LinkWith ("libUAirship-1.2.0.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7,
-                     Frameworks = "MobileCoreServices", LinkerFlags = "-lsqlite3", ForceLoad = true)]
+                     Frameworks = "CFNetwork CoreGraphics Foundation MobileCoreServices Security SystemConfiguration UIKit CoreTelephony StoreKit CoreLocation", LinkerFlags = "-lsqlite3", ForceLoad = true)]


### PR DESCRIPTION
Added required frameworks per UrbanAirship guidelines: https://docs.urbanairship.com/display/DOCS/Getting+Started:+iOS:+Push#GettingStartediOSPush-2DownloadInstallourLibraryFrameworks

libUAirship 1.2 available @ http://com.urbanairship.filereleases.s3.amazonaws.com/libUAirship-1.2.0.zip
