### PR TITLE
CCSpriteFrameCahce.SharedSpriteFrameCache was (again?) missing

### DIFF
--- a/cocos2d/binding/ApiDefinition.cs
+++ b/cocos2d/binding/ApiDefinition.cs
@@ -3329,6 +3329,10 @@ namespace MonoTouch.Cocos2D {
 
 	[BaseType (typeof (NSObject))]
 	interface CCSpriteFrameCache {
+		[Static]
+		[Export("sharedSpriteFrameCache")]
+		CCSpriteFrameCache SharedSpriteFrameCache { get; }
+
 		[Export ("addSpriteFramesWithFile:")]
 		void AddSpriteFrames (string plist);
 


### PR DESCRIPTION
Stephane said he had that property already added but maybe it was overseen in the end. Anyway: it's there now.
