### PR TITLE
[cocos2d] Clean the TextAlignment

### DIFF
--- a/cocos2d/binding/ApiDefinition.cs
+++ b/cocos2d/binding/ApiDefinition.cs
@@ -27,6 +27,10 @@ using MonoTouch.Foundation;
 using MonoTouch.ObjCRuntime;
 using MonoTouch.CoreGraphics;
 using MonoTouch.UIKit;
+#if MONOMAC
+using UITextAlignment = MonoMac.AppKit.NSTextAlignment;
+using UILineBreakMode = MonoMac.AppKit.NSLineBreakMode;
+#endif
 
 using ARCH_OPTIMAL_PARTICLE_SYSTEM = MonoTouch.Cocos2D.CCParticleSystemQuad;
 
@@ -895,18 +899,12 @@ namespace MonoTouch.Cocos2D {
 #endif
 
 		[Export ("initWithString:fontName:fontSize:dimensions:hAlignment:vAlignment:lineBreakMode:")]
-#if MONOMAC
-		IntPtr Constructor (string text, string fontName, float fontSize, SizeF dimensions, NSTextAlignment alignment, CCVerticalTextAlignment vertAlignment, NSLineBreakMode lineBreakMode);
-#else
+		[PrologueSnippet ("if ((int)alignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"alignment\");")]
 		IntPtr Constructor (string text, string fontName, float fontSize, SizeF dimensions, UITextAlignment alignment, CCVerticalTextAlignment vertAlignment, UILineBreakMode lineBreakMode);
-#endif
 
 		[Export ("initWithString:fontName:fontSize:dimensions:hAlignment:vAlignment:")]
-#if MONOMAC
-		IntPtr Constructor (string text, string fontName, float fontSize, SizeF dimensions, NSTextAlignment alignment, CCVerticalTextAlignment vertAlignment);
-#else
+		[PrologueSnippet ("if ((int)alignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"alignment\");")]
 		IntPtr Constructor (string text, string fontName, float fontSize, SizeF dimensions, UITextAlignment alignment, CCVerticalTextAlignment vertAlignment);
-#endif
 
 		[Export ("initWithString:fontName:fontSize:")]
 		IntPtr Constructor (string text, string fontName, float fontSize);
@@ -1377,32 +1375,20 @@ namespace MonoTouch.Cocos2D {
 		IntPtr Constructor (string label, string fontName, float fontSize);
 
 		[Export ("initWithString:fontName:fontSize:dimensions:halignment:")]
-#if MONOMAC
-		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, NSTextAlignment halignment);
-#else
+		[PrologueSnippet ("if ((int)halignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"halignment\");")]
 		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, UITextAlignment halignment);
-#endif
 
 		[Export ("initWithString:fontName:fontSize:dimensions:halignment:lineBreakMode:")]
-#if MONOMAC
-		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, NSTextAlignment halignment, NSLineBreakMode lineBreakMode);
-#else
+		[PrologueSnippet ("if ((int)halignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"halignment\");")]
 		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, UITextAlignment halignment, UILineBreakMode lineBreakMode);
-#endif
 
 		[Export ("initWithString:fontName:fontSize:dimensions:halignment:vAlignment:")]
-#if MONOMAC
-		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, NSTextAlignment halignment, CCVerticalTextAlignment vertAlignment);
-#else
+		[PrologueSnippet ("if ((int)halignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"halignment\");")]
 		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, UITextAlignment halignment, CCVerticalTextAlignment vertAlignment);
-#endif
 
 		[Export ("initWithString:fontName:fontSize:dimensions:halignment:vAlignment:lineBreakMode:")]
-#if MONOMAC
-		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, NSTextAlignment halignment, CCVerticalTextAlignment vertAlignment, NSLineBreakMode lineBreakMode);
-#else
+		[PrologueSnippet ("if ((int)halignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"halignment\");")]
 		IntPtr Constructor (string label, string fontName, float fontSize, SizeF dimensions, UITextAlignment halignment, CCVerticalTextAlignment vertAlignment, UILineBreakMode lineBreakMode);
-#endif
 	}
 	
 	[BaseType (typeof(CCSpriteBatchNode))]
@@ -1412,11 +1398,11 @@ namespace MonoTouch.Cocos2D {
 		void PurgeCachedData  ();
 
 		[Export("alignment")]
-#if MONOMAC
-		NSTextAlignment Alignment { get; set; }
-#else
-		UITextAlignment Alignment { get; set; }
-#endif
+		UITextAlignment Alignment { 
+			get; 
+			[PrologueSnippet ("if ((int)value >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"alignment\");")]
+			set; 
+		}
 
 		[Export("fntFile")]
 		string FontFile { get; set; }
@@ -1425,18 +1411,12 @@ namespace MonoTouch.Cocos2D {
 		CCLabelBMFont Constructor (string label, string fontFile);
 
 		[Export ("initWithString:fntFile:width:alignment:")]
-#if MONOMAC
-		IntPtr Constructor (string label, string fontFile, float width, NSTextAlignment alignment);
-#else
+		[PrologueSnippet ("if ((int)alignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"alignment\");")]
 		IntPtr Constructor (string label, string fontFile, float width, UITextAlignment alignment);
-#endif
 
 		[Export ("initWithString:fntFile:width:alignment:imageOffset:")]
-#if MONOMAC
-		IntPtr Constructor (string label, string fontFile, float width, NSTextAlignment alignment, PointF offset);
-#else
+		[PrologueSnippet ("if ((int)alignment >= 3) throw new ArgumentException (\"Justified and Natural alignments not supported\", \"alignment\");")]
 		IntPtr Constructor (string label, string fontFile, float width, UITextAlignment alignment, PointF offset);
-#endif
 
 		[Export ("createFontChars")]
 		void CreateFontChars ();

--- a/cocos2d/binding/Extra.cs
+++ b/cocos2d/binding/Extra.cs
@@ -13,6 +13,11 @@ using System.Runtime.InteropServices;
 using MonoTouch.Foundation;
 using MonoTouch.ObjCRuntime;
 using MonoTouch.UIKit;
+#if MONOMAC
+using UITextAlignment = MonoMac.AppKit.NSTextAlignment;
+using UILineBreakMode = MonoMac.AppKit.NSLineBreakMode;
+#endif
+
 
 namespace MonoTouch.Cocos2D {
 	// Use this for synchronous operations
@@ -212,31 +217,19 @@ namespace MonoTouch.Cocos2D {
 
 	public partial class CCTexture2D {
 		[Obsolete ("Obsolete since 2.1. Use CCTexture2D (string text, string fontName, float fontSize, UITextAlignment alignmenr, CCVerticalTextAlignment vertAlignmenr) instead.")]
-#if MONOMAC
-		public CCTexture2D (string text, SizeF dimensions, NSTextAlignment alignment, CCVerticalTextAlignment vertAlignment, string fontName, float fontSize) : this (text, fontName, fontSize, dimensions, alignment, vertAlignment)
-#else
 		public CCTexture2D (string text, SizeF dimensions, UITextAlignment alignment, CCVerticalTextAlignment vertAlignment, string fontName, float fontSize) : this (text, fontName, fontSize, dimensions, alignment, vertAlignment)
-#endif
 		{
 		}
 	}
 
 	public partial class CCLabelTTF {
 		[Obsolete ("Obsolete since 2.1. Use CCLabelTTF (string label, string fontName, float fontSize, SizeF dimensions, UITextAlignment alignment, UILineBreakMode lineBreakMode) instead.")]
-#if MONOMAC
-		public CCLabelTTF (string label, SizeF dimensions, NSTextAlignment alignment, NSLineBreakMode lineBreakMode, string fontName, float fontSize) : this (label, fontName, fontSize, dimensions, alignment, lineBreakMode)
-#else
 		public CCLabelTTF (string label, SizeF dimensions, UITextAlignment alignment, UILineBreakMode lineBreakMode, string fontName, float fontSize) : this (label, fontName, fontSize, dimensions, alignment, lineBreakMode)
-#endif
 		{
 		}
 
 		[Obsolete ("Obsolete since 2.1, Use CCLabelTTF (string label, string fontName, float fontSize, SizeF dimensions, UITextAlignment alignment) instead.")]
-#if MONOMAC
-		public CCLabelTTF (string label, SizeF dimensions, NSTextAlignment alignment, string fontName, float fontSize) : this (label, fontName, fontSize, dimensions, alignment)
-#else
 		public CCLabelTTF (string label, SizeF dimensions, UITextAlignment alignment, string fontName, float fontSize) : this (label, fontName, fontSize, dimensions, alignment)
-#endif
 		{
 		}
 	}


### PR DESCRIPTION
use UITextAlignment on iOS, NSTextAlignment on OSX. Prevent using
Justified or Natural alignments as it's not supported by cocos2d
