### PR TITLE
[GoogleAnalytics] Fix data type issue with currency micros.

### DIFF
--- a/GoogleAnalytics/binding/googleanalytics.cs
+++ b/GoogleAnalytics/binding/googleanalytics.cs
@@ -138,13 +138,13 @@ namespace GoogleAnalytics {
 		string Affiliation { get;  }
 		
 		[Export ("revenueMicros")]
-		int RevenueMicros { get; set;  }
+		long RevenueMicros { get; set;  }
 		
 		[Export ("taxMicros")]
-		int TaxMicros { get; set;  }
+		long TaxMicros { get; set;  }
 		
 		[Export ("shippingMicros")]
-		int ShippingMicros { get; set;  }
+		long ShippingMicros { get; set;  }
 		
 		[Export ("items")]
 		GAITransactionItem[] Items { get;  }
@@ -157,7 +157,7 @@ namespace GoogleAnalytics {
 		void AddItem (GAITransactionItem item);
 		
 		[Export ("addItemWithCode:name:category:priceMicros:quantity:")]
-		void AddItem (string productCode, string productName, string productCategory, int priceMicros, int quantity);
+		void AddItem (string productCode, string productName, string productCategory, long priceMicros, int quantity);
 		
 	}
 	[BaseType (typeof (NSObject))]
@@ -172,14 +172,14 @@ namespace GoogleAnalytics {
 		string ProductCategory { get; set;  }
 		
 		[Export ("priceMicros")]
-		int PriceMicros { get; set;  }
+		long PriceMicros { get; set;  }
 		
 		[Export ("quantity")]
 		int Quantity { get; set;  }
 		
 		[Static]
 		[Export ("itemWithCode:name:category:priceMicros:quantity:")]
-		GAITransactionItem ItemFrom (string productCode, string productName, string productCategory, int priceMicros, int quantity);
+		GAITransactionItem ItemFrom (string productCode, string productName, string productCategory, long priceMicros, int quantity);
 		
 	}
 	


### PR DESCRIPTION
When I submitted a test transaction to Google Analytics using the bindings here, I got some odd data showing in the Google Analytics dashboard.

![googleanalyticsfail](https://f.cloud.github.com/assets/713665/645208/a3403666-d39f-11e2-985e-248a1ee2904c.png)

> On a side note, if you look closely, Google Analytics doesn't appear to handle very large negative numbers very well (`-4 + -4 = +9`).

[Google's Objective-C code](https://developers.google.com/analytics/devguides/collection/ios/v2/ecommerce#implementation) suggests an `int64_t` for these values.

```
transaction.revenueMicros = (int64_t)(2.16 * 1000000);
```

I thought it might be some sort of overflow issue and swapped out the C# binding for those currency values from `int` to `long` and the data started showing up correctly in the dashboard.

![googleanalyticsfailfixed](https://f.cloud.github.com/assets/713665/645209/a3543d28-d39f-11e2-8d47-14141506130f.png)
