### PR TITLE
[Flurry Analytics] Update link targets for compatibility with latest sdk...

### DIFF
--- a/FlurryAnalytics/binding/AssemblyInfo.cs
+++ b/FlurryAnalytics/binding/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System;
 using MonoTouch.ObjCRuntime;
 
-[assembly: LinkWith ("libFlurry.a", LinkTarget.Simulator | LinkTarget.ArmV7,Frameworks = "SystemConfiguration", ForceLoad = true)]
+[assembly: LinkWith ("libFlurry.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s, ForceLoad = true)]


### PR DESCRIPTION
... 4.2.3. Should now build against latest libFlurry.a which is 4.2.3
