### PR TITLE
Checkout Facebook SDK 3.5.2 (commit 56b40a4e75) instead of HEAD

### DIFF
--- a/facebook/binding/Makefile
+++ b/facebook/binding/Makefile
@@ -10,6 +10,7 @@ all: MonoTouch.FacebookConnect.dll
 
 facebook-ios-sdk:
 	git clone git@github.com:facebook/facebook-ios-sdk.git
+	(cd facebook-ios-sdk; git checkout 56b40a4e75)
 
 libFacebook-i386.a: facebook-ios-sdk
 	$(XBUILD) -project $(PROJECT) -target $(TARGET) -sdk iphonesimulator -configuration Release clean build


### PR DESCRIPTION
Solves the build issue caused by the Facebook SDK being far ahead (currently 3.7) of the version supported by the binding project (3.5.2).
