### PR TITLE
Add setter to FBSettings.AppVersion

### DIFF
--- a/facebook/binding/ApiDefinition.cs
+++ b/facebook/binding/ApiDefinition.cs
@@ -1618,7 +1618,7 @@ namespace MonoTouch.FacebookConnect
 	
 		[Static]
 		[Export ("appVersion")]
-		string AppVersion { get; }
+		string AppVersion { get; set; }
 
 		[Static]
 		[Export ("clientToken")]


### PR DESCRIPTION
From the [FB documentation](https://developers.facebook.com/docs/reference/ios/current/constants/FBSettings):

```
setAppVersion:
Sets the application version to the provided string. FBAppEvents, for instance, attaches the app version to events that it logs, which are then available in App Insights.

+ (void)setAppVersion:(NSString *)appVersion;
Parameter
appVersion
The version identifier of the iOS app.
```
