### PR TITLE
Fix the Google.Maps.WebTilesReceiver I/F definition in ApiDefinition.cs

### DIFF
--- a/GoogleMaps/binding/ApiDefinition.cs
+++ b/GoogleMaps/binding/ApiDefinition.cs
@@ -953,14 +953,16 @@ namespace Google.Maps
 
 		[Abstract]
 		[Export ("receiveTileWithX:y:zoom:image:")]
-		void RecieveTile (uint x, uint y, uint zoom, UIImage image);
+		void ReceiveTile (uint x, uint y, uint zoom, [NullAllowed] UIImage image);
 	}
+
+	interface ITileReceiver {}
 
 	[BaseType (typeof (NSObject), Name="GMSTileLayer")]
 	interface TileLayer {
 
 		[Export ("requestTileForX:y:zoom:receiver:")]
-		void RequestTile (uint x, uint y, uint zoom, TileReceiver receiver);
+		void RequestTile (uint x, uint y, uint zoom, ITileReceiver receiver);
 
 		[Export ("clearTileCache")]
 		void ClearTileCache ();


### PR DESCRIPTION
As reported in Xamarin forum,
http://forums.xamarin.com/discussion/9020/google-maps-ios-components-v1-5-0-contains-bug-at-async-interface-of-tilelayer#latest
Google.Maps.WebTilesReceiver I/F contains bug in it's definition.

I changed it and it becomes working well.
