### PR TITLE
AdSupport no longer required

### DIFF
--- a/GoogleAnalytics/binding/libGoogleAnalyticsServices.linkwith.cs
+++ b/GoogleAnalytics/binding/libGoogleAnalyticsServices.linkwith.cs
@@ -1,4 +1,4 @@
 using System;
 using MonoTouch.ObjCRuntime;
 
-[assembly: LinkWith ("libGoogleAnalyticsServices.a", LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator, Frameworks = "CoreData SystemConfiguration AdSupport", SmartLink = true, ForceLoad = true, LinkerFlags = "-lz -lsqlite3.0 -ObjC -fobjc-arc")]
+[assembly: LinkWith ("libGoogleAnalyticsServices.a", LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Simulator, Frameworks = "CoreData SystemConfiguration", SmartLink = true, ForceLoad = true, LinkerFlags = "-lz -lsqlite3.0 -ObjC -fobjc-arc")]


### PR DESCRIPTION
According to the latest Google Analytics SDK, AdSupport is not listed anywhere. https://developers.google.com/analytics/devguides/collection/ios/v3/
