### PR TITLE
Updated test flight binding to 3.0

### DIFF
--- a/TestFlight/README.md
+++ b/TestFlight/README.md
@@ -5,7 +5,7 @@ This is a MonoTouch binding for the TestFlight SDK which can be found at
 
      https://testflightapp.com/sdk/
 
-The current version of this binding is for TestFlight SDK 2.0.2 released on 30 August 2013
+The current version of this binding is for TestFlight SDK 3.0.0 released on 19 Feb 2014
 
 Building
 ========

--- a/TestFlight/binding/AssemblyInfo.cs
+++ b/TestFlight/binding/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 using System;
 using MonoTouch.ObjCRuntime;
 
-[assembly: LinkWith ("libTestFlight.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s, ForceLoad = true)]
-[assembly: LinkWith ("libarclite.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7, ForceLoad = true)]
+[assembly: LinkWith ("libTestFlight.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Arm64, ForceLoad = true)]
+[assembly: LinkWith ("libarclite.a", LinkTarget.Simulator | LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.Arm64, ForceLoad = true)]

--- a/TestFlight/binding/Makefile
+++ b/TestFlight/binding/Makefile
@@ -1,5 +1,5 @@
 BTOUCH=/Developer/MonoTouch/usr/bin/btouch
-VERSION=2.0.2
+VERSION=3.0.0
 all: TestFlight.dll
 
 TestFlightSDK$(VERSION).zip:

--- a/TestFlight/binding/testflight.cs
+++ b/TestFlight/binding/testflight.cs
@@ -55,19 +55,6 @@ namespace MonoTouch.TestFlight {
 		[Static, Export ("submitFeedback:")]
 		void SubmitFeedback (string feedback);
 
-		/// <summary>
-		/// Sets the device identifier.
-		/// DO NOT CALL THIS IN A APPSTORE APP!!!
-		/// Your app won't be processed if you do!
-		/// 
-		/// If you want to use this during testing, you have to call it before TakeOff / ThreadSafeTakeOff
-		/// </summary>
-		/// <param name="deviceIdentifer"> Only use this with the Apple device UDID. DO NOT use Open ID or your own identifier</param>
-		[Obsolete("You cannot use this anymore with Xamarin")]
-		[Static, Export ("setDeviceIdentifier:")]
-		void SetDeviceIdentifier (string deviceIdentifer);
-
-
 	}
 
 	[Static]


### PR DESCRIPTION
- Updated test flight binding to 3.0.0 in makefile
- Updated Readme.md with new version information
- Updated LinkTargets to include Arm64
- Remove SetDeviceIdentifier from binding as this has been removed
  from the TestFlight SDK
