### PR TITLE
updated hockeyapp version to 3.6.1

### DIFF
--- a/HockeyApp/binding/HockeyApp.iOS.csproj
+++ b/HockeyApp/binding/HockeyApp.iOS.csproj
@@ -61,8 +61,6 @@
     <BundleResource Include="HockeySDKResources.bundle\authorize_denied.png" />
     <BundleResource Include="HockeySDKResources.bundle\authorize_denied%402x.png" />
     <BundleResource Include="HockeySDKResources.bundle\bg.png" />
-    <BundleResource Include="HockeySDKResources.bundle\buttonHighlight.png" />
-    <BundleResource Include="HockeySDKResources.bundle\buttonHighlight%402x.png" />
     <BundleResource Include="HockeySDKResources.bundle\buttonRoundedDelete.png" />
     <BundleResource Include="HockeySDKResources.bundle\buttonRoundedDelete%402x.png" />
     <BundleResource Include="HockeySDKResources.bundle\buttonRoundedDeleteHighlighted.png" />
@@ -86,8 +84,26 @@
     <BundleResource Include="HockeySDKResources.bundle\nl.lproj\HockeySDK.strings" />
     <BundleResource Include="HockeySDKResources.bundle\pt-PT.lproj\HockeySDK.strings" />
     <BundleResource Include="HockeySDKResources.bundle\pt.lproj\HockeySDK.strings" />
-    <BundleResource Include="HockeySDKResources.bundle\ro.lproj\HockeySDK.strings" />
     <BundleResource Include="HockeySDKResources.bundle\ru.lproj\HockeySDK.strings" />
     <BundleResource Include="HockeySDKResources.bundle\zh-Hans.lproj\HockeySDK.strings" />
+    <BundleResource Include="HockeySDKResources.bundle\Arrow.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Arrow%402x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Arrow%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Blur.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Blur%402x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Blur%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Cancel.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Cancel%402x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Cancel%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Ok.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Ok%402x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Ok%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Rectangle.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Rectangle%402x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\Rectangle%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\authorize_denied%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\feedbackActivity%403x.png" />
+    <BundleResource Include="HockeySDKResources.bundle\iconCamera.png" />
+    <BundleResource Include="HockeySDKResources.bundle\iconCamera%402x.png" />
   </ItemGroup>
 </Project>

--- a/HockeyApp/binding/Makefile
+++ b/HockeyApp/binding/Makefile
@@ -2,8 +2,8 @@ BTOUCH=/Developer/MonoTouch/usr/bin/btouch
 SMCS=/Developer/MonoTouch/usr/bin/smcs
 MONOXBUILD=/Library/Frameworks/Mono.framework/Commands/xbuild
 MDTOOL=/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool
-VERSION=3.5.4
-# HockeyApp iOS Version 3.5.4
+VERSION=3.6.1
+# HockeyApp iOS Version 3.6.1
 
 all: HockeyApp.iOS.dll
 


### PR DESCRIPTION
The current version of hockey app is 3.5.4 which was released on February 2014.

The current version of the hockey app sdk is 3.6.1. https://github.com/bitstadium/HockeySDK-iOS/releases

Builds okay, I updated the references to files in the bundle for files which were removed and files which were added.
