### PR TITLE
Hockeyapp update to 3.5.7

### DIFF
--- a/HockeyApp/binding/Makefile
+++ b/HockeyApp/binding/Makefile
@@ -2,8 +2,8 @@ BTOUCH=/Developer/MonoTouch/usr/bin/btouch
 SMCS=/Developer/MonoTouch/usr/bin/smcs
 MONOXBUILD=/Library/Frameworks/Mono.framework/Commands/xbuild
 MDTOOL=/Applications/Xamarin\ Studio.app/Contents/MacOS/mdtool
-VERSION=3.5.4
-# HockeyApp iOS Version 3.5.4
+VERSION=3.5.7
+# HockeyApp iOS Version 3.5.7
 
 all: HockeyApp.iOS.dll
 


### PR DESCRIPTION
This version of hockey app is 3.5.4 which was released on February 2014.

3.5.7 is the most recently released patch version. This updates to that patch version. However, the most recent version of the HockeyApp SDK is 3.6.1 but is non-trivial to update. See #223 

https://github.com/bitstadium/HockeySDK-iOS/releases

Builds, and does not cause build error when building in a xamarin iOS project.