### PR TITLE
[MagTek.iDynamo] Fix up native library slices

### DIFF
--- a/MagTek.iDynamo/README.md
+++ b/MagTek.iDynamo/README.md
@@ -4,35 +4,22 @@ MagTek.iDynamo
 These are bindings to MagTek's native iDynamo SDK for iOS from
 http://www.magtek.com/support/software/programming_tools/
 
+Building
+========
+
+Run `make' in the binding directory to build MagTek.iDynamo.dll.
+
 Using
 =====
 
 Copy the MagTek.iDynamo.dll project in the binding directory to your
 project, and add it as a reference in your project.
 
-Building
-========
-
-Run `make' in the binding directory to build MagTek.iDynamo.dll.
-
 Sample
 ======
 
 The sample program in sample/ is a partial port of MagTek's sample iDynamo
 program, it covers about half of the features in it.
-
-ARMv7 support
-=============
-
-The downloaded static library contains duplicate symbols for ARMv7 that
-results in an error when linking ARMv7 projects (e.g. for an iPad app).
-The fix requires some minor surgery on the static library:
-	* split the .a into both an armv6 and armv7 .a (lipo -thin) 
-	* decompress the armv7.a (ar -x)
-	* the duplicate will overwrite themselves, no work required
-	* recompress the armv7.a library (libtool -static)
-	* merge the (old) armv6 and the new armv7 libraries (lip -create)
-	* rebuild the bindings
 
 License
 =======

--- a/MagTek.iDynamo/binding/AssemblyInfo.cs
+++ b/MagTek.iDynamo/binding/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System;
 using MonoTouch.ObjCRuntime;
 
-[assembly: LinkWith ("libMTSCRA.a", LinkTarget.ArmV6 | LinkTarget.ArmV7 | LinkTarget.Thumb, "-lc++", Frameworks = "AudioToolbox CoreGraphics ExternalAccessory", ForceLoad = true, IsCxx = true)]
+[assembly: LinkWith ("libMTSCRA.a", LinkTarget.Simulator | LinkTarget.ArmV7 | LinkTarget.ArmV7s | LinkTarget.Thumb, "-lc++", Frameworks = "AudioToolbox CoreGraphics ExternalAccessory", ForceLoad = true, IsCxx = true)]

--- a/MagTek.iDynamo/binding/Makefile
+++ b/MagTek.iDynamo/binding/Makefile
@@ -7,8 +7,14 @@ all: MagTek.iDynamo.dll
 $(ZIP_VERSION).zip:
 	curl http://www.magtek.com/support/software/downloads/sw/$@ > $@
 
-libMTSCRA.a: $(ZIP_VERSION).zip
+libMTSCRA_ios.a: $(ZIP_VERSION).zip
 	unzip -p $< '$(ZIP_VERSION)/Lib/Release-iphoneos/libMTSCRA.a' > $@ || rm -f $@
+
+libMTSCRA_sim.a: $(ZIP_VERSION).zip
+	unzip -p $< '$(ZIP_VERSION)/Lib/Release-iphonesimulator/libMTSCRA.a' > $@ || rm -f $@
+
+libMTSCRA.a: libMTSCRA_ios.a libMTSCRA_sim.a
+	lipo -create -output $@ $^
 
 MagTek.iDynamo.dll: Makefile MagTek.iDynamo.cs enums.cs AssemblyInfo.cs libMTSCRA.a
 	$(BTOUCH) -out:$@ MagTek.iDynamo.cs -s:enums.cs -x:AssemblyInfo.cs --link-with=libMTSCRA.a,libMTSCRA.a


### PR DESCRIPTION
I think the downloaded zip contents changed at some point, but retained the same file name?  Not sure what happened, really.

The native library no longer contains an ARMv6 slice, so I removed that from the binding.
The native library now contains an ARMv7s slice, so I added that to the binding.

I also added a slice to support the simulator.  I guess it could be argued that this library is useless in the simulator, but I didn't like having the build warning.

The "ARMv7 support" section of the ReadMe is no longer applicable, so I removed it.

