### PR TITLE
Enabling localDataStore

### DIFF
--- a/Parse/binding/ParseLib.cs
+++ b/Parse/binding/ParseLib.cs
@@ -34,6 +34,10 @@ namespace ParseTouch
 		[Static]
 		[Export ("setApplicationId:clientKey:")]
 		void SetAppId (string applicationId, string clientKey);
+		
+		[Static]
+		[Export ("enableLocalDatastore")]
+		void EnableLocalDatastore ();		
 
 		[Static]
 		[Export ("offlineMessagesEnabled:")]


### PR DESCRIPTION
Binding for the enableLocalDataStore method. The rest of the feature seems to be already implemented, as the ParseObject.SaveEventually method is already bound.
